### PR TITLE
fixed android root src

### DIFF
--- a/index.android.js
+++ b/index.android.js
@@ -1,5 +1,5 @@
 import React from "react-native";
-import Root from "./containers/root";
+import Root from "./src/containers/root";
 
 const {
   AppRegistry


### PR DESCRIPTION
`index.android.js` was importing `Root` from the wrong directory `import Root from "./containers/root";
` 
