### PR TITLE
Fix Flow link in README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -35,7 +35,7 @@ To lint your code using [ESLint](http://eslint.org/) run `npm run lint`
 
 #### Type Checking
 
-To type check your code using [Flow](flowtype.org), first [install Flow](http://flowtype.org/docs/getting-started.html#_) and then run `npm run flow`
+To type check your code using [Flow](http://flowtype.org), first [install Flow](http://flowtype.org/docs/getting-started.html#_) and then run `npm run flow`
 
 #### Troubleshooting
 


### PR DESCRIPTION
Small fix. Flow link is pointing to wrong place. 

Expected: http://flowtype.org/
Actual: https://github.com/FormidableLabs/formidable-react-native-app-boilerplate/blob/master/flowtype.org

:smile: :beers: 
